### PR TITLE
Add namespaces and operator groups for telemetry

### DIFF
--- a/install_operators.sh
+++ b/install_operators.sh
@@ -17,11 +17,12 @@ oc apply -f ./resources/subscriptions.yaml
 echo "Waiting till all operators pods are ready"
 until oc get pods -n openshift-operators | grep servicemesh-operator3 | grep Running; do echo "Waiting for servicemesh-operator3 to be running."; sleep 10;done
 until oc get pods -n openshift-operators | grep kiali-operator | grep Running; do echo "Waiting for kiali-operator to be running."; sleep 10;done
-until oc get pods -n openshift-operators | grep opentelemetry-operator | grep Running; do echo "Waiting for opentelemetry-operator to be running."; sleep 10;done
-until oc get pods -n openshift-operators | grep tempo-operator | grep Running; do echo "Waiting for tempo-operator to be running."; sleep 10;done
+until oc get pods -n openshift-opentelemetry-operator | grep opentelemetry-operator | grep Running; do echo "Waiting for opentelemetry-operator to be running."; sleep 10;done
+until oc get pods -n openshift-tempo-operator | grep tempo-operator | grep Running; do echo "Waiting for tempo-operator to be running."; sleep 10;done
 
 echo "All operators were installed successfully"
 oc get pods -n openshift-operators
 
+# This is for legacy OCP versions that do not have Gateway API enabled by default - safe to keep for now
 echo "Enabling Gateway API"
 oc get crd gateways.gateway.networking.k8s.io &> /dev/null ||  { oc kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v1.0.0" | oc apply -f -; }

--- a/resources/subscriptions.yaml
+++ b/resources/subscriptions.yaml
@@ -1,3 +1,36 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-opentelemetry-operator
+  labels:
+    openshift.io/cluster-monitoring: 'true'
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-tempo-operator
+  labels:
+    openshift.io/cluster-monitoring: 'true'
+# =======================================================
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-opentelemetry-operator
+  namespace: openshift-opentelemetry-operator
+spec:
+  upgradeStrategy: Default
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-tempo-operator
+  namespace: openshift-tempo-operator
+spec:
+  upgradeStrategy: Default
+# =======================================================
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -26,8 +59,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: opentelemetry-product
-  namespace: openshift-operators
-  sourceNamespace: openshift-marketplace
+  namespace: openshift-opentelemetry-operator
 spec:
   channel: stable
   installPlanApproval: Automatic
@@ -39,7 +71,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: tempo-product
-  namespace: openshift-operators
+  namespace: openshift-tempo-operator
 spec:
   channel: stable
   installPlanApproval: Automatic


### PR DESCRIPTION
Update operator deployment stuff with the right namespaces for where they're meant to be installed to